### PR TITLE
fix: 블로그 포스트 canonical URL 절대 경로로 변경

### DIFF
--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -55,7 +55,7 @@ export async function generateMetadata({ params }: { params: Promise<{ slug: str
       description,
     },
     alternates: {
-      canonical: `/posts/${postId}`,
+      canonical: `https://dglog.vercel.app/posts/${postId}`,
     },
   };
 }


### PR DESCRIPTION
## 변경 사항
- 블로그 포스트 페이지의 canonical URL을 상대 경로(`/posts/${postId}`)에서 절대 경로(`https://dglog.vercel.app/posts/${postId}`)로 변경했습니다.

## 변경 이유
- 검색 엔진은 canonical URL의 절대 경로를 더 선호합니다.
- 절대 경로를 사용하면 검색 엔진이 중복 콘텐츠를 더 정확하게 식별할 수 있습니다.
- 같은 콘텐츠가 다른 URL로 접근 가능할 때 발생할 수 있는 SEO 패널티를 방지합니다.

## 기술적 설명
- `generateMetadata` 함수 내에서 canonical URL을 절대 경로로 변경했습니다.
- URL 구조는 동일하게 유지하면서 도메인을 추가하여 절대 경로를 구성했습니다.

## 영향
- 블로그 포스트의 SEO 점수가 향상될 수 있습니다.
- 검색 엔진 크롤러가 사이트 구조를 더 정확하게 이해할 수 있습니다.