### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main, master, dev]
 
+permissions:
+  contents: read
+
 jobs:
   test:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Potential fix for [https://github.com/YEONDG/dglog/security/code-scanning/1](https://github.com/YEONDG/dglog/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. Since this workflow only performs testing, linting, and dependency installation, it does not require write permissions. The minimal required permission is `contents: read`, which allows the workflow to access the repository's contents without granting write access. This change ensures the workflow adheres to the principle of least privilege.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
